### PR TITLE
Optimize Playwright Workflow Triggers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,8 +2,34 @@ name: Playwright Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'config/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'tsconfig.*.json'
+      - 'vite.config.ts'
+      - 'postcss.config.js'
+      - 'tailwind.config.js'
+      - '.github/workflows/playwright.yml'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'config/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'tsconfig.*.json'
+      - 'vite.config.ts'
+      - 'postcss.config.js'
+      - 'tailwind.config.js'
+      - '.github/workflows/playwright.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Updated `.github/workflows/playwright.yml` to include a `paths` filter for both `push` and `pull_request` triggers. This ensures that the end-to-end tests only run when changes are made to source code, tests, or configuration files, optimizing CI resource usage.

---
*PR created automatically by Jules for task [10859927556027859167](https://jules.google.com/task/10859927556027859167) started by @g1ddy*