### PR TITLE
💎 Refract: Refactor Coach components from React.FC to function declarations

### DIFF
--- a/src/features/coach/components/AnalystPanel.tsx
+++ b/src/features/coach/components/AnalystPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BoardStats, GameState } from '../../../game/core/types';
 import { RefreshCw } from 'lucide-react';
 
@@ -9,7 +8,7 @@ export interface AnalystPanelProps {
   G?: GameState;
 }
 
-const AnalystPanel: React.FC<AnalystPanelProps> = ({ stats, onRegenerate, canRegenerate = true }) => {
+function AnalystPanel({ stats, onRegenerate, canRegenerate = true }: AnalystPanelProps) {
   const getFairnessColorClass = (score: number) => {
     if (score >= 90) return 'text-green-400';
     if (score >= 70) return 'text-orange-400';

--- a/src/features/coach/components/AnalystShell.tsx
+++ b/src/features/coach/components/AnalystShell.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useIsMobile } from '../../shared/hooks/useIsMobile';
 import { X, ChevronLeft } from 'lucide-react';
 import { Z_INDEX_OVERLAY_PANEL } from '../../shared/constants/z-indices';
@@ -10,7 +9,7 @@ interface AnalystShellProps {
   onToggle: () => void;
 }
 
-export const AnalystShell: React.FC<AnalystShellProps> = ({ children, isOpen, onToggle }) => {
+export function AnalystShell({ children, isOpen, onToggle }: AnalystShellProps) {
   const isMobile = useIsMobile();
 
   // Desktop: Sidebar

--- a/src/features/coach/components/CoachPanel.tsx
+++ b/src/features/coach/components/CoachPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Ctx } from 'boardgame.io';
 import { GameState } from '../../../game/core/types';
 import { StrategicAdvice } from '../../../game/analysis/coach';

--- a/src/features/coach/components/CoachPanel.tsx
+++ b/src/features/coach/components/CoachPanel.tsx
@@ -6,7 +6,7 @@ import { PlayerProductionPotential } from './PlayerProductionPotential';
 
 export interface CoachPanelProps {
     G?: GameState;
-    ctx: Ctx;
+    ctx?: Ctx;
     showResourceHeatmap: boolean;
     setShowResourceHeatmap: (show: boolean) => void;
     isCoachModeEnabled: boolean;
@@ -16,7 +16,6 @@ export interface CoachPanelProps {
 
 export function CoachPanel({
     G,
-    ctx,
     showResourceHeatmap,
     setShowResourceHeatmap,
     isCoachModeEnabled,

--- a/src/features/coach/components/CoachPanel.tsx
+++ b/src/features/coach/components/CoachPanel.tsx
@@ -14,14 +14,15 @@ export interface CoachPanelProps {
     advice?: StrategicAdvice | null;
 }
 
-export const CoachPanel: React.FC<CoachPanelProps> = ({
+export function CoachPanel({
     G,
+    ctx,
     showResourceHeatmap,
     setShowResourceHeatmap,
     isCoachModeEnabled,
     setIsCoachModeEnabled,
     advice
-}) => {
+}: CoachPanelProps) {
     return (
         <div className="text-slate-100 h-full flex flex-col gap-6">
 

--- a/src/features/coach/components/PlayerProduction.tsx
+++ b/src/features/coach/components/PlayerProduction.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Player } from '../../../game/core/types';
 import { RESOURCE_META } from '../../shared/config/uiConfig';
 
@@ -12,7 +11,7 @@ interface PlayerProductionRowProps {
     potentials: Record<string, number>;
 }
 
-const PlayerProductionRow: React.FC<PlayerProductionRowProps> = ({ player, potentials }) => {
+function PlayerProductionRow({ player, potentials }: PlayerProductionRowProps) {
     const resourcePips = RESOURCE_META.map(({ name, bgColor }) => ({
         name,
         color: bgColor,
@@ -60,9 +59,9 @@ const PlayerProductionRow: React.FC<PlayerProductionRowProps> = ({ player, poten
             </div>
         </div>
     );
-};
+}
 
-export const PlayerProduction: React.FC<PlayerProductionProps> = ({ playerPotentials, players }) => {
+export function PlayerProduction({ playerPotentials, players }: PlayerProductionProps) {
     return (
         <div className="flex flex-col gap-3 mt-4">
             <h4 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">Player Production</h4>

--- a/src/features/coach/components/PlayerProductionPotential.tsx
+++ b/src/features/coach/components/PlayerProductionPotential.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { GameState } from '../../../game/core/types';
 import { calculatePlayerPotentialPips } from '../../../game/analysis/analyst';
 import { ResourceIconRow } from '../../shared/components/ResourceIconRow';
@@ -9,7 +8,7 @@ interface PlayerProductionPotentialProps {
     G?: GameState;
 }
 
-export const PlayerProductionPotential: React.FC<PlayerProductionPotentialProps> = ({ G }) => {
+export function PlayerProductionPotential({ G }: PlayerProductionPotentialProps) {
     if (!G) return null;
 
     const playerPotentials = calculatePlayerPotentialPips(G);


### PR DESCRIPTION
🐛 **Problem:** Legacy `React.FC` pattern is widely used in `src/features/coach/components` which can make Generics clunky and doesn't align with React 19 standards. The `import React from 'react'` in these modules also became completely unused under modern JSX transforms.

🛠 **Fix:** Converted `PlayerProduction`, `AnalystShell`, `PlayerProductionPotential`, `CoachPanel`, and `AnalystPanel` to semantic function declarations (`export function Component(props: Props)`). Removed unused React imports safely.

📉 **Risk:** Low (Type and structure only, no business logic was changed).

🧪 **Verification:** Successfully ran TypeScript verification `npx tsc --noEmit`, ESLint checking `npm run lint`, and passing unit/e2e tests `npm test`. Code Review passed.

---
*PR created automatically by Jules for task [2881675036797487442](https://jules.google.com/task/2881675036797487442) started by @g1ddy*