### PR TITLE
💎 Refract: Remove React.FC in HUD Components

### DIFF
--- a/src/features/hud/components/GameControls.tsx
+++ b/src/features/hud/components/GameControls.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { GameState, ClientMoves } from '../../../game/core/types';
 import { Ctx } from 'boardgame.io';
 import { safeMove } from '../../shared/utils/feedback';
@@ -27,7 +26,7 @@ export interface GameControlsProps {
     playerID?: string | null;
 }
 
-export const GameControls: React.FC<GameControlsProps> = ({
+export function GameControls({
     G,
     ctx,
     moves,
@@ -40,7 +39,7 @@ export const GameControls: React.FC<GameControlsProps> = ({
     advice = null,
     pendingRobberHex,
     playerID = null
-}) => {
+}: GameControlsProps) {
     const {
         isSetup,
         isGameplay,

--- a/src/features/hud/components/GameNotification.tsx
+++ b/src/features/hud/components/GameNotification.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { GameState, RollStatus } from '../../../game/core/types';
 import { Dices, Ghost } from 'lucide-react';
 import { DiceIcons } from '../../shared/components/DiceIcons';
@@ -10,7 +9,7 @@ export interface GameNotificationProps {
     G: GameState;
 }
 
-export const GameNotification: React.FC<GameNotificationProps> = ({ G }) => {
+export function GameNotification({ G }: GameNotificationProps) {
     const isRolling = G.rollStatus === RollStatus.ROLLING;
     const { visible, displayNotification } = useAutoDismissNotification(G.notification, isRolling);
 

--- a/src/features/hud/components/controls/BuildBar.tsx
+++ b/src/features/hud/components/controls/BuildBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Handshake } from 'lucide-react';
 import { BUILD_COSTS, BANK_TRADE_GIVE_AMOUNT, BANK_TRADE_RECEIVE_AMOUNT } from '../../../../game/core/config';
 import { BUILD_BUTTON_CONFIG } from '../../../shared/config/uiConfig';
@@ -18,7 +17,7 @@ interface BuildBarProps {
     advice: StrategicAdvice | null;
 }
 
-export const BuildBar: React.FC<BuildBarProps> = ({
+export function BuildBar({
     affordMap,
     isMoveAllowed,
     buildMode,
@@ -28,7 +27,7 @@ export const BuildBar: React.FC<BuildBarProps> = ({
     onTrade,
     isCoachModeEnabled,
     advice
-}) => {
+}: BuildBarProps) {
     const moveNameMap: Record<string, string> = {
         road: 'buildRoad',
         settlement: 'buildSettlement',

--- a/src/features/hud/components/controls/RobberControls.tsx
+++ b/src/features/hud/components/controls/RobberControls.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ActionButton } from './ActionButton';
 
 interface RobberControlsProps {
@@ -7,11 +6,11 @@ interface RobberControlsProps {
     className?: string;
 }
 
-export const RobberControls: React.FC<RobberControlsProps> = ({
+export function RobberControls({
     pendingRobberHex,
     onConfirm,
     className = ''
-}) => {
+}: RobberControlsProps) {
     const hasSelection = !!pendingRobberHex;
 
     return (

--- a/src/features/hud/components/controls/SetupControls.tsx
+++ b/src/features/hud/components/controls/SetupControls.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { STAGES } from '../../../../game/core/constants';
 import { UiMode } from '../../../shared/types';
 import { ActionButton } from './ActionButton';
@@ -11,13 +10,13 @@ interface SetupControlsProps {
     isMyTurn: boolean;
 }
 
-export const SetupControls: React.FC<SetupControlsProps> = ({
+export function SetupControls({
     uiMode,
     setUiMode,
     activeStage,
     className = '',
     isMyTurn
-}) => {
+}: SetupControlsProps) {
     const canInteract = isMyTurn && (activeStage === STAGES.PLACE_SETTLEMENT || activeStage === STAGES.PLACE_ROAD);
 
     const handleClick = () => {

--- a/src/features/hud/components/controls/TurnControls.tsx
+++ b/src/features/hud/components/controls/TurnControls.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Loader2, ArrowRight, Dices as Dice } from 'lucide-react';
 import { RollStatus } from '../../../../game/core/types';
 
@@ -13,7 +12,7 @@ interface TurnControlsProps {
     isRollingStage: boolean;
 }
 
-export const TurnControls: React.FC<TurnControlsProps> = ({
+export function TurnControls({
     isMoveAllowed,
     isEndingTurn,
     onEndTurn,
@@ -22,7 +21,7 @@ export const TurnControls: React.FC<TurnControlsProps> = ({
     rollStatus,
     lastRoll,
     isRollingStage
-}) => {
+}: TurnControlsProps) {
     const endTurnLabel = isEndingTurn ? "Ending..." : "End";
     const endTurnLabelDesktop = isEndingTurn ? "Ending Turn..." : "End Turn";
     const endTurnIcon = isEndingTurn ? <Loader2 size={16} className="animate-spin motion-reduce:animate-none" aria-hidden="true" /> : <ArrowRight size={16} aria-hidden="true" />;

--- a/src/features/hud/components/notifications/RobberNotification.tsx
+++ b/src/features/hud/components/notifications/RobberNotification.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { RobberEvent, Player } from '../../../../game/core/types';
 import { safeGet } from '../../../../game/core/utils/objectUtils';
 import { ArrowRight } from 'lucide-react';
@@ -9,7 +8,7 @@ interface RobberNotificationProps {
     players: Record<string, Player>;
 }
 
-export const RobberNotification: React.FC<RobberNotificationProps> = ({ evt, players }) => {
+export function RobberNotification({ evt, players }: RobberNotificationProps) {
     // Validate players exist
     const thief = safeGet(players, evt.thief);
     const victim = safeGet(players, evt.victim);


### PR DESCRIPTION
🐛 **Problem:** Several components in `src/features/hud/components/` (and its `controls` subdirectory) were using the legacy `React.FC` type alongside arrow functions, which is discouraged in modern React 19 standards. Additionally, many of these files had redundant `import React from 'react';` statements that are no longer necessary with the new JSX transform.

🛠 **Fix:** Refactored the following components to use standard, semantic function declarations instead of `React.FC`:
- `GameControls.tsx`
- `GameNotification.tsx`
- `RobberNotification.tsx`
- `BuildBar.tsx`
- `RobberControls.tsx`
- `SetupControls.tsx`
- `TurnControls.tsx`

📉 **Risk:** Low. The refactor is purely syntactic and does not alter any props logic, hook usage, or business logic.

🧪 **Verification:** 
- Ran type checking via `npx tsc --noEmit` and confirmed no errors.
- Ran linting via `npm run lint` and confirmed no errors.
- Executed `npm test` and ensured all tests passed successfully.

---
*PR created automatically by Jules for task [7329197509296504963](https://jules.google.com/task/7329197509296504963) started by @g1ddy*