### PR TITLE
⚡ Bolt: Replace chained .map().find() in HexEdges

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2026-03-31 - Memoizing Deterministic State Lookups in Render Loops
 **Learning:** Iterating through string arrays and performing object property lookups (`safeCheck` on `G.board.hexes`) to determine UI ownership for hundreds of vertices/edges per frame causes a measurable performance drop. Because the board topology is effectively static during gameplay, these checks constantly yield the same result.
 **Action:** Use a simple JavaScript `Map` to cache the result of deterministic state lookups based on their input parameters (e.g., `parts.join('|')`). Invalidate the cache only when the underlying state reference (`G.board.hexes`) actually changes, rather than recalculating on every React render.
+## 2025-02-18 - Replacing chained array methods in hot loops
+**Learning:** Chaining array methods like `.map().find()` inside a high-frequency React render loop (e.g., iterating through board edges) forces full O(N) evaluation of the `.map` mapping function and allocates intermediate arrays, significantly increasing Garbage Collection pressure and degrading performance.
+**Action:** Replace these chains with a single `for...of` loop and use an early `break` as soon as the target element is found. This short-circuits the expensive operations and reduces memory allocation.

--- a/src/features/board/components/HexEdges.tsx
+++ b/src/features/board/components/HexEdges.tsx
@@ -110,7 +110,12 @@ export const HexEdges: React.FC<HexEdgesProps> = ({
 
                 let portElement = null;
                 if (port) {
-                    const portOwner = port.vertices.map(vId => safeGet(G.board.vertices, vId)?.owner).find(Boolean);
+                    let portOwner = null;
+                    // Bolt optimization: Replaced chained .map().find() with a short-circuiting loop to prevent unnecessary allocations and safeGet calls in the hot render loop.
+                    for (const vId of port.vertices) {
+                        portOwner = safeGet(G.board.vertices, vId)?.owner;
+                        if (portOwner) break;
+                    }
                     portElement = (
                         <Port key={`port-${eId}`} cx={midX} cy={midY} angle={angle} type={port.type}
                               ownerColor={portOwner ? G.players[portOwner]?.color : null}


### PR DESCRIPTION
**💡 What:** Replaced a chained `.map().find()` operation with a short-circuiting `for...of` loop in the `HexEdges` component's hot render loop.
**🎯 Why:** To eliminate unnecessary array allocations and avoid redundant expensive state lookups (`safeGet`) during frequent React renders.
**📊 Impact:** Reduces Garbage Collection pressure and eliminates unnecessary object iterations.
**🔬 Measurement:** Verified via test passing, linting, and typescript compilation without functionally altering the render result.

---
*PR created automatically by Jules for task [2687734943187893287](https://jules.google.com/task/2687734943187893287) started by @g1ddy*