### PR TITLE
💎 Refract: Refactor shared components to React 19 function declarations

### DIFF
--- a/src/features/coach/components/AnalystPanel.tsx
+++ b/src/features/coach/components/AnalystPanel.tsx
@@ -70,6 +70,6 @@ function AnalystPanel({ stats, onRegenerate, canRegenerate = true }: AnalystPane
       </div>
     </div>
   );
-};
+}
 
 export default AnalystPanel;

--- a/src/features/coach/components/AnalystShell.tsx
+++ b/src/features/coach/components/AnalystShell.tsx
@@ -90,4 +90,4 @@ export function AnalystShell({ children, isOpen, onToggle }: AnalystShellProps) 
       </div>
     </>
   );
-};
+}

--- a/src/features/coach/components/CoachPanel.tsx
+++ b/src/features/coach/components/CoachPanel.tsx
@@ -85,4 +85,4 @@ export function CoachPanel({
             </div>
         </div>
     );
-};
+}

--- a/src/features/coach/components/PlayerProduction.tsx
+++ b/src/features/coach/components/PlayerProduction.tsx
@@ -76,4 +76,4 @@ export function PlayerProduction({ playerPotentials, players }: PlayerProduction
             </div>
         </div>
     );
-};
+}

--- a/src/features/coach/components/PlayerProductionPotential.tsx
+++ b/src/features/coach/components/PlayerProductionPotential.tsx
@@ -39,4 +39,4 @@ export function PlayerProductionPotential({ G }: PlayerProductionPotentialProps)
             <ResourceDistribution playerPotentials={playerPotentials} players={G.players} />
         </div>
     );
-};
+}

--- a/src/features/hud/components/GameControls.tsx
+++ b/src/features/hud/components/GameControls.tsx
@@ -118,4 +118,4 @@ export function GameControls({
     }
 
     return null;
-};
+}

--- a/src/features/hud/components/GameNotification.tsx
+++ b/src/features/hud/components/GameNotification.tsx
@@ -69,4 +69,4 @@ export function GameNotification({ G }: GameNotificationProps) {
             </div>
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/BuildBar.tsx
+++ b/src/features/hud/components/controls/BuildBar.tsx
@@ -123,4 +123,4 @@ export function BuildBar({
             })}
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/RobberControls.tsx
+++ b/src/features/hud/components/controls/RobberControls.tsx
@@ -27,4 +27,4 @@ export function RobberControls({
             />
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/SetupControls.tsx
+++ b/src/features/hud/components/controls/SetupControls.tsx
@@ -50,4 +50,4 @@ export function SetupControls({
              />
          </div>
     );
-};
+}

--- a/src/features/hud/components/controls/TurnControls.tsx
+++ b/src/features/hud/components/controls/TurnControls.tsx
@@ -75,4 +75,4 @@ export function TurnControls({
             )}
         </>
     );
-};
+}

--- a/src/features/hud/components/notifications/RobberNotification.tsx
+++ b/src/features/hud/components/notifications/RobberNotification.tsx
@@ -56,4 +56,4 @@ export function RobberNotification({ evt, players }: RobberNotificationProps) {
             )}
         </div>
     );
-};
+}

--- a/src/features/shared/components/DiceIcons.tsx
+++ b/src/features/shared/components/DiceIcons.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import {
     Dice1, Dice2, Dice3, Dice4, Dice5, Dice6, Dices, LucideIcon
 } from 'lucide-react';
 
-interface DiceIconsProps {
+export interface DiceIconsProps {
     d1: number;
     d2: number;
     size?: number;
@@ -20,13 +19,13 @@ const DICE_ICONS: Record<number, LucideIcon> = {
     6: Dice6
 };
 
-export const DiceIcons: React.FC<DiceIconsProps> = ({
+export function DiceIcons({
     d1,
     d2,
     size = 20,
     className = '',
     ariaLabel
-}) => {
+}: DiceIconsProps) {
     // eslint-disable-next-line security/detect-object-injection -- 'd1' is a number validated by typescript and gracefully falls back to default icon
     const Die1Icon = DICE_ICONS[d1] || Dices;
     // eslint-disable-next-line security/detect-object-injection -- 'd2' is a number validated by typescript and gracefully falls back to default icon
@@ -42,4 +41,4 @@ export const DiceIcons: React.FC<DiceIconsProps> = ({
             <Die2Icon size={size} className={className} aria-hidden="true" />
         </div>
     );
-};
+}

--- a/src/features/shared/components/ResourceIconRow.tsx
+++ b/src/features/shared/components/ResourceIconRow.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import { Resources } from '../../../game/core/types';
 import { RESOURCE_META } from '../config/uiConfig';
 
-interface ResourceIconRowProps {
+export interface ResourceIconRowProps {
   resources: Partial<Resources> | Record<string, number>;
   size?: 'sm' | 'md';
   className?: string;
 }
 
-export const ResourceIconRow: React.FC<ResourceIconRowProps> = ({ resources, size = 'sm', className = '' }) => {
+export function ResourceIconRow({ resources, size = 'sm', className = '' }: ResourceIconRowProps) {
   const iconSize = size === 'sm' ? 12 : 16;
   const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
 
@@ -34,4 +33,4 @@ export const ResourceIconRow: React.FC<ResourceIconRowProps> = ({ resources, siz
         })}
     </div>
   );
-};
+}


### PR DESCRIPTION
* 🐛 Problem: Legacy `React.FC` pattern and unused `React` imports were used in shared components (`DiceIcons` and `ResourceIconRow`), which is deprecated in modern React (React 17+ JSX transform and React 19 standards).
* 🛠 Fix: Converted `React.FC` arrow functions to semantic function declarations (`export function...`) and removed the unused `import React from 'react'`.
* 📉 Risk: Low. Purely syntactic changes, no logic modified.
* 🧪 Verification: Ran `npx tsc --noEmit`, `npm run lint`, and unit tests (`npm test -- src/features/shared/components/`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12883748685398469265](https://jules.google.com/task/12883748685398469265) started by @g1ddy*