### PR TITLE
⚡ Bolt: Replace chained map().find() with for...of in HexEdges

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-03-31 - Memoizing Deterministic State Lookups in Render Loops
 **Learning:** Iterating through string arrays and performing object property lookups (`safeCheck` on `G.board.hexes`) to determine UI ownership for hundreds of vertices/edges per frame causes a measurable performance drop. Because the board topology is effectively static during gameplay, these checks constantly yield the same result.
 **Action:** Use a simple JavaScript `Map` to cache the result of deterministic state lookups based on their input parameters (e.g., `parts.join('|')`). Invalidate the cache only when the underlying state reference (`G.board.hexes`) actually changes, rather than recalculating on every React render.
+
+## 2024-04-28 - Intermediate Array Allocations in Render Loops
+**Learning:** Chaining array methods like `.map().find()` inside a hot render loop (e.g., iterating over edges in `HexEdges.tsx`) forces the creation of intermediate arrays, increasing garbage collection pressure. Additionally, it prevents early exit once the desired element is found.
+**Action:** Replace chained `.map().find()` or similar iterations with zero-allocation `for...of` loops and use `break` to exit early once the condition is met.

--- a/src/features/board/components/HexEdges.tsx
+++ b/src/features/board/components/HexEdges.tsx
@@ -110,7 +110,14 @@ export const HexEdges: React.FC<HexEdgesProps> = ({
 
                 let portElement = null;
                 if (port) {
-                    const portOwner = port.vertices.map(vId => safeGet(G.board.vertices, vId)?.owner).find(Boolean);
+                    let portOwner: string | undefined;
+                    for (const vId of port.vertices) {
+                        const owner = safeGet(G.board.vertices, vId)?.owner;
+                        if (owner) {
+                            portOwner = owner;
+                            break;
+                        }
+                    }
                     portElement = (
                         <Port key={`port-${eId}`} cx={midX} cy={midY} angle={angle} type={port.type}
                               ownerColor={portOwner ? G.players[portOwner]?.color : null}

--- a/src/features/coach/components/AnalystPanel.tsx
+++ b/src/features/coach/components/AnalystPanel.tsx
@@ -70,6 +70,6 @@ function AnalystPanel({ stats, onRegenerate, canRegenerate = true }: AnalystPane
       </div>
     </div>
   );
-};
+}
 
 export default AnalystPanel;

--- a/src/features/coach/components/AnalystShell.tsx
+++ b/src/features/coach/components/AnalystShell.tsx
@@ -90,4 +90,4 @@ export function AnalystShell({ children, isOpen, onToggle }: AnalystShellProps) 
       </div>
     </>
   );
-};
+}

--- a/src/features/coach/components/CoachPanel.tsx
+++ b/src/features/coach/components/CoachPanel.tsx
@@ -85,4 +85,4 @@ export function CoachPanel({
             </div>
         </div>
     );
-};
+}

--- a/src/features/coach/components/PlayerProduction.tsx
+++ b/src/features/coach/components/PlayerProduction.tsx
@@ -76,4 +76,4 @@ export function PlayerProduction({ playerPotentials, players }: PlayerProduction
             </div>
         </div>
     );
-};
+}

--- a/src/features/coach/components/PlayerProductionPotential.tsx
+++ b/src/features/coach/components/PlayerProductionPotential.tsx
@@ -39,4 +39,4 @@ export function PlayerProductionPotential({ G }: PlayerProductionPotentialProps)
             <ResourceDistribution playerPotentials={playerPotentials} players={G.players} />
         </div>
     );
-};
+}

--- a/src/features/hud/components/GameControls.tsx
+++ b/src/features/hud/components/GameControls.tsx
@@ -118,4 +118,4 @@ export function GameControls({
     }
 
     return null;
-};
+}

--- a/src/features/hud/components/GameNotification.tsx
+++ b/src/features/hud/components/GameNotification.tsx
@@ -69,4 +69,4 @@ export function GameNotification({ G }: GameNotificationProps) {
             </div>
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/BuildBar.tsx
+++ b/src/features/hud/components/controls/BuildBar.tsx
@@ -123,4 +123,4 @@ export function BuildBar({
             })}
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/RobberControls.tsx
+++ b/src/features/hud/components/controls/RobberControls.tsx
@@ -27,4 +27,4 @@ export function RobberControls({
             />
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/SetupControls.tsx
+++ b/src/features/hud/components/controls/SetupControls.tsx
@@ -50,4 +50,4 @@ export function SetupControls({
              />
          </div>
     );
-};
+}

--- a/src/features/hud/components/controls/TurnControls.tsx
+++ b/src/features/hud/components/controls/TurnControls.tsx
@@ -75,4 +75,4 @@ export function TurnControls({
             )}
         </>
     );
-};
+}

--- a/src/features/hud/components/notifications/RobberNotification.tsx
+++ b/src/features/hud/components/notifications/RobberNotification.tsx
@@ -56,4 +56,4 @@ export function RobberNotification({ evt, players }: RobberNotificationProps) {
             )}
         </div>
     );
-};
+}


### PR DESCRIPTION
**💡 What:** Replaced a chained `.map().find()` operation (`port.vertices.map(vId => safeGet(G.board.vertices, vId)?.owner).find(Boolean)`) in `src/features/board/components/HexEdges.tsx` with a standard `for...of` loop and an early `break`.

**🎯 Why:** The `HexEdges` component is a high-frequency render loop. The chained `.map().find()` approach forces the creation of an intermediate array and iterates through all elements before searching, increasing garbage collection (GC) pressure. A `for...of` loop requires zero intermediate allocations and allows for immediate termination (`break`) once an owner is found.

**📊 Impact:** Eliminates intermediate array allocations per port during the render loop. Also provides a micro-optimization by exiting early once the first truthy value is encountered instead of evaluating all vertices.

**🔬 Measurement:**
- Passed all linter checks (`npm run lint`).
- Passed production build (`npm run build`).
- Passed full test suite without breaking any logic (`npm run test`).

---
*PR created automatically by Jules for task [9440286298114109349](https://jules.google.com/task/9440286298114109349) started by @g1ddy*