### PR TITLE
💎 Refract: Remove legacy React.FC in remaining components

### DIFF
--- a/src/features/board/BoardLayer.tsx
+++ b/src/features/board/BoardLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { HexGrid, Layout } from 'react-hexgrid';
 import { Tooltip } from 'react-tooltip';

--- a/src/features/board/BoardLayer.tsx
+++ b/src/features/board/BoardLayer.tsx
@@ -30,7 +30,7 @@ interface BoardLayerProps {
     onHexClick: (hex: Hex) => void;
 }
 
-export const BoardLayer: React.FC<BoardLayerProps> = ({
+export function BoardLayer({
     G,
     ctx,
     moves,
@@ -43,7 +43,7 @@ export const BoardLayer: React.FC<BoardLayerProps> = ({
     highlightedPortEdgeId,
     pendingRobberHex,
     onHexClick
-}) => {
+}: BoardLayerProps) {
     const hexes = Object.values(G.board.hexes);
     const { producingHexIds } = useGameEffects(G);
     const { validSettlements, validCities, validRoads } = useBoardInteractions(G, ctx, ctx.currentPlayer);

--- a/src/features/board/components/BuildingIcon.tsx
+++ b/src/features/board/components/BuildingIcon.tsx
@@ -10,7 +10,7 @@ interface BuildingIconProps {
     ownerColor: string | null | undefined;
 }
 
-export const BuildingIcon: React.FC<BuildingIconProps> = ({ vertex, corner, ownerColor }) => {
+export function BuildingIcon({ vertex, corner, ownerColor }: BuildingIconProps) {
     const isSettlement = vertex.type === 'settlement';
     const Icon = isSettlement ? Home : Castle;
     const size = isSettlement ? SETTLEMENT_ICON_SIZE : CITY_ICON_SIZE;

--- a/src/features/board/components/BuildingIcon.tsx
+++ b/src/features/board/components/BuildingIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Home, Castle } from 'lucide-react';
 
 const SETTLEMENT_ICON_SIZE = 5;

--- a/src/features/board/components/GameHex.tsx
+++ b/src/features/board/components/GameHex.tsx
@@ -25,7 +25,7 @@ const getPipsCount = (num: number): number => {
   return PIPS_MAP[num] || 0;
 };
 
-const GameHexComponent: React.FC<GameHexProps> = ({ hex, onClick, isProducing, hasRobber, isPendingRobber }) => {
+function GameHexComponent({ hex, onClick, isProducing, hasRobber, isPendingRobber }: GameHexProps) {
   const color = TERRAIN_COLORS[hex.terrain];
   const pips = getPipsCount(hex.tokenValue || 0);
 

--- a/src/features/board/components/HexEdges.tsx
+++ b/src/features/board/components/HexEdges.tsx
@@ -73,10 +73,10 @@ interface HexEdgesProps {
     coachData?: CoachData;
 }
 
-export const HexEdges: React.FC<HexEdgesProps> = ({
+export function HexEdges({
     edges, G, ctx, moves, buildMode, setBuildMode, uiMode, setUiMode,
     validRoads, highlightedPortEdgeId, currentHexIdStr, coachData
-}) => {
+}: HexEdgesProps) {
     // Stable handler setup
     const stateRef = useRef({ G, ctx, moves, buildMode, setBuildMode, uiMode, setUiMode, validRoads });
     stateRef.current = { G, ctx, moves, buildMode, setBuildMode, uiMode, setUiMode, validRoads };

--- a/src/features/board/components/HexVertices.tsx
+++ b/src/features/board/components/HexVertices.tsx
@@ -78,10 +78,10 @@ interface HexVerticesProps {
     currentHexIdStr: string;
 }
 
-export const HexVertices: React.FC<HexVerticesProps> = ({
+export function HexVertices({
     vertices, G, ctx, moves, buildMode, setBuildMode, uiMode,
     validSettlements, validCities, coachData, showResourceHeatmap, currentHexIdStr
-}) => {
+}: HexVerticesProps) {
     // Stable handler setup
     const stateRef = useRef({ G, ctx, moves, buildMode, setBuildMode, uiMode, validSettlements, validCities });
     stateRef.current = { G, ctx, moves, buildMode, setBuildMode, uiMode, validSettlements, validCities };

--- a/src/features/board/components/HexVertices.tsx
+++ b/src/features/board/components/HexVertices.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { BoardProps } from 'boardgame.io/react';
 import { GameState, ClientMoves } from '../../../game/core/types';
 import { BuildMode, UiMode } from '../../shared/types';

--- a/src/features/game/GameLayout.tsx
+++ b/src/features/game/GameLayout.tsx
@@ -28,7 +28,7 @@ interface GameLayoutProps {
   onPanelChange: (panel: 'analyst' | 'coach' | null) => void;
 }
 
-export const GameLayout: React.FC<GameLayoutProps> = ({
+export function GameLayout({
   board,
   dashboard,
   playerPanel,
@@ -38,7 +38,7 @@ export const GameLayout: React.FC<GameLayoutProps> = ({
   coachPanel,
   activePanel,
   onPanelChange
-}) => {
+}: GameLayoutProps) {
   const isMobile = useIsMobile();
 
   const togglePanel = (panel: 'analyst' | 'coach') => {

--- a/src/features/game/GameScreen.tsx
+++ b/src/features/game/GameScreen.tsx
@@ -18,7 +18,7 @@ export interface GameScreenProps extends BoardProps<GameState> {
   onPlayerChange?: (playerID: string) => void;
 }
 
-export const GameScreen: React.FC<GameScreenProps> = ({ G, ctx, moves, playerID, onPlayerChange }) => {
+export function GameScreen({ G, ctx, moves, playerID, onPlayerChange }: GameScreenProps) {
     // 1. Core State & Logic (Extracted)
     const {
         showResourceHeatmap,

--- a/src/features/shared/components/DiceIcons.tsx
+++ b/src/features/shared/components/DiceIcons.tsx
@@ -20,13 +20,13 @@ const DICE_ICONS: Record<number, LucideIcon> = {
     6: Dice6
 };
 
-export const DiceIcons: React.FC<DiceIconsProps> = ({
+export function DiceIcons({
     d1,
     d2,
     size = 20,
     className = '',
     ariaLabel
-}) => {
+}: DiceIconsProps) {
     // eslint-disable-next-line security/detect-object-injection -- 'd1' is a number validated by typescript and gracefully falls back to default icon
     const Die1Icon = DICE_ICONS[d1] || Dices;
     // eslint-disable-next-line security/detect-object-injection -- 'd2' is a number validated by typescript and gracefully falls back to default icon

--- a/src/features/shared/components/DiceIcons.tsx
+++ b/src/features/shared/components/DiceIcons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Dice1, Dice2, Dice3, Dice4, Dice5, Dice6, Dices, LucideIcon
 } from 'lucide-react';

--- a/src/features/shared/components/ResourceIconRow.tsx
+++ b/src/features/shared/components/ResourceIconRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Resources } from '../../../game/core/types';
 import { RESOURCE_META } from '../config/uiConfig';
 

--- a/src/features/shared/components/ResourceIconRow.tsx
+++ b/src/features/shared/components/ResourceIconRow.tsx
@@ -8,7 +8,7 @@ interface ResourceIconRowProps {
   className?: string;
 }
 
-export const ResourceIconRow: React.FC<ResourceIconRowProps> = ({ resources, size = 'sm', className = '' }) => {
+export function ResourceIconRow({ resources, size = 'sm', className = '' }: ResourceIconRowProps) {
   const iconSize = size === 'sm' ? 12 : 16;
   const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
 


### PR DESCRIPTION
🐛 **Problem:**
Legacy `React.FC` patterns were still being used across several components in the `game`, `board`, and `shared` feature directories, which is discouraged in modern React 19 standards.

🛠 **Fix:**
Refactored these components to use standard, semantic function declarations instead of anonymous arrow functions assigned to `React.FC`. This simplifies typing, improves stack traces, and removes the deprecated implicit `children` prop behavior from React 17 and earlier.

📉 **Risk:**
Low. Mechanical refactoring only. No business logic or state management was changed.

🧪 **Verification:**
- Ran `npx tsc --noEmit` and confirmed no type errors.
- Ran `npm run lint` to ensure style compliance.
- Ran `npm test` and explicitly tested the modified `shared` components (`DiceIcons`, `ResourceIconRow`) and coach test dependencies. All tests passed.

---
*PR created automatically by Jules for task [3237637225966831119](https://jules.google.com/task/3237637225966831119) started by @g1ddy*