### PR TITLE
💎 Refract: Remove React.FC in Game and Board components

### DIFF
--- a/src/features/board/BoardLayer.tsx
+++ b/src/features/board/BoardLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { HexGrid, Layout } from 'react-hexgrid';
 import { Tooltip } from 'react-tooltip';
@@ -30,7 +30,7 @@ interface BoardLayerProps {
     onHexClick: (hex: Hex) => void;
 }
 
-export const BoardLayer: React.FC<BoardLayerProps> = ({
+export function BoardLayer({
     G,
     ctx,
     moves,
@@ -43,7 +43,7 @@ export const BoardLayer: React.FC<BoardLayerProps> = ({
     highlightedPortEdgeId,
     pendingRobberHex,
     onHexClick
-}) => {
+}: BoardLayerProps) {
     const hexes = Object.values(G.board.hexes);
     const { producingHexIds } = useGameEffects(G);
     const { validSettlements, validCities, validRoads } = useBoardInteractions(G, ctx, ctx.currentPlayer);

--- a/src/features/board/components/BuildingIcon.tsx
+++ b/src/features/board/components/BuildingIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Home, Castle } from 'lucide-react';
 
 const SETTLEMENT_ICON_SIZE = 5;
@@ -10,7 +9,7 @@ interface BuildingIconProps {
     ownerColor: string | null | undefined;
 }
 
-export const BuildingIcon: React.FC<BuildingIconProps> = ({ vertex, corner, ownerColor }) => {
+export function BuildingIcon({ vertex, corner, ownerColor }: BuildingIconProps) {
     const isSettlement = vertex.type === 'settlement';
     const Icon = isSettlement ? Home : Castle;
     const size = isSettlement ? SETTLEMENT_ICON_SIZE : CITY_ICON_SIZE;

--- a/src/features/board/components/GameHex.tsx
+++ b/src/features/board/components/GameHex.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 import { Hexagon } from 'react-hexgrid';
 import { Skull } from 'lucide-react';
 import { Hex } from '../../../game/core/types';
@@ -25,7 +25,7 @@ const getPipsCount = (num: number): number => {
   return PIPS_MAP[num] || 0;
 };
 
-const GameHexComponent: React.FC<GameHexProps> = ({ hex, onClick, isProducing, hasRobber, isPendingRobber }) => {
+function GameHexComponent({ hex, onClick, isProducing, hasRobber, isPendingRobber }: GameHexProps) {
   const color = TERRAIN_COLORS[hex.terrain];
   const pips = getPipsCount(hex.tokenValue || 0);
 
@@ -60,4 +60,4 @@ const GameHexComponent: React.FC<GameHexProps> = ({ hex, onClick, isProducing, h
   );
 };
 
-export const GameHex = React.memo(GameHexComponent);
+export const GameHex = memo(GameHexComponent);

--- a/src/features/board/components/HexEdges.tsx
+++ b/src/features/board/components/HexEdges.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import { useRef, useCallback, Fragment } from 'react';
 import { BoardProps } from 'boardgame.io/react';
 import { GameState, ClientMoves } from '../../../game/core/types';
 import { BuildMode, UiMode } from '../../shared/types';
@@ -73,10 +73,10 @@ interface HexEdgesProps {
     coachData?: CoachData;
 }
 
-export const HexEdges: React.FC<HexEdgesProps> = ({
+export function HexEdges({
     edges, G, ctx, moves, buildMode, setBuildMode, uiMode, setUiMode,
     validRoads, highlightedPortEdgeId, currentHexIdStr, coachData
-}) => {
+}: HexEdgesProps) {
     // Stable handler setup
     const stateRef = useRef({ G, ctx, moves, buildMode, setBuildMode, uiMode, setUiMode, validRoads });
     stateRef.current = { G, ctx, moves, buildMode, setBuildMode, uiMode, setUiMode, validRoads };
@@ -123,7 +123,7 @@ export const HexEdges: React.FC<HexEdgesProps> = ({
                 );
 
                 return (
-                    <React.Fragment key={eId}>
+                    <Fragment key={eId}>
                         <OverlayEdge eId={eId} cx={midX} cy={midY} angle={angle} isOccupied={!!edge}
                                      ownerColor={ownerColor} isClickable={isClickable}
                                      isGhost={isGhost} onClick={handleEdgeClick}
@@ -131,7 +131,7 @@ export const HexEdges: React.FC<HexEdgesProps> = ({
                                      heatmapColor={heatmapColor}
                                      tooltip={tooltip} />
                         {portElement}
-                    </React.Fragment>
+                    </Fragment>
                 );
             })}
         </>

--- a/src/features/board/components/HexVertices.tsx
+++ b/src/features/board/components/HexVertices.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { BoardProps } from 'boardgame.io/react';
 import { GameState, ClientMoves } from '../../../game/core/types';
 import { BuildMode, UiMode } from '../../shared/types';
@@ -78,10 +78,10 @@ interface HexVerticesProps {
     currentHexIdStr: string;
 }
 
-export const HexVertices: React.FC<HexVerticesProps> = ({
+export function HexVertices({
     vertices, G, ctx, moves, buildMode, setBuildMode, uiMode,
     validSettlements, validCities, coachData, showResourceHeatmap, currentHexIdStr
-}) => {
+}: HexVerticesProps) {
     // Stable handler setup
     const stateRef = useRef({ G, ctx, moves, buildMode, setBuildMode, uiMode, validSettlements, validCities });
     stateRef.current = { G, ctx, moves, buildMode, setBuildMode, uiMode, validSettlements, validCities };

--- a/src/features/game/GameLayout.tsx
+++ b/src/features/game/GameLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import {
     Z_INDEX_BOARD,
     Z_INDEX_TOOLTIP,
@@ -17,18 +17,18 @@ import { CoachShell } from '../coach/components/CoachShell';
 import { renderCostTooltip, renderDiceTooltip, renderTradeTooltip } from './components/TooltipRenderers';
 
 interface GameLayoutProps {
-  board: React.ReactNode;
-  dashboard: React.ReactNode;
-  playerPanel: React.ReactNode;
-  gameControls: React.ReactNode;
-  gameStatus?: React.ReactNode;
-  gameNotification?: React.ReactNode;
-  coachPanel: React.ReactNode;
+  board: ReactNode;
+  dashboard: ReactNode;
+  playerPanel: ReactNode;
+  gameControls: ReactNode;
+  gameStatus?: ReactNode;
+  gameNotification?: ReactNode;
+  coachPanel: ReactNode;
   activePanel: 'analyst' | 'coach' | null;
   onPanelChange: (panel: 'analyst' | 'coach' | null) => void;
 }
 
-export const GameLayout: React.FC<GameLayoutProps> = ({
+export function GameLayout({
   board,
   dashboard,
   playerPanel,
@@ -38,7 +38,7 @@ export const GameLayout: React.FC<GameLayoutProps> = ({
   coachPanel,
   activePanel,
   onPanelChange
-}) => {
+}: GameLayoutProps) {
   const isMobile = useIsMobile();
 
   const togglePanel = (panel: 'analyst' | 'coach') => {

--- a/src/features/game/GameScreen.tsx
+++ b/src/features/game/GameScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useMemo } from 'react';
 import { BoardProps } from 'boardgame.io/react';
 import { GameState, ClientMoves } from '../../game/core/types';
 import { GameLayout } from './GameLayout';
@@ -18,7 +18,7 @@ export interface GameScreenProps extends BoardProps<GameState> {
   onPlayerChange?: (playerID: string) => void;
 }
 
-export const GameScreen: React.FC<GameScreenProps> = ({ G, ctx, moves, playerID, onPlayerChange }) => {
+export function GameScreen({ G, ctx, moves, playerID, onPlayerChange }: GameScreenProps) {
     // 1. Core State & Logic (Extracted)
     const {
         showResourceHeatmap,
@@ -40,7 +40,7 @@ export const GameScreen: React.FC<GameScreenProps> = ({ G, ctx, moves, playerID,
     } = useGameScreenState(G, ctx, playerID, onPlayerChange);
 
     // 2. Derived State (Coach Advice)
-    const strategicAdvice: StrategicAdvice | null = React.useMemo(() => {
+    const strategicAdvice: StrategicAdvice | null = useMemo(() => {
         if (!isCoachModeEnabled) return null;
         const coach = new Coach(G);
         return coach.getStrategicAdvice(ctx.currentPlayer, ctx);

--- a/src/features/shared/components/DiceIcons.tsx
+++ b/src/features/shared/components/DiceIcons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Dice1, Dice2, Dice3, Dice4, Dice5, Dice6, Dices, LucideIcon
 } from 'lucide-react';
@@ -20,13 +19,13 @@ const DICE_ICONS: Record<number, LucideIcon> = {
     6: Dice6
 };
 
-export const DiceIcons: React.FC<DiceIconsProps> = ({
+export function DiceIcons({
     d1,
     d2,
     size = 20,
     className = '',
     ariaLabel
-}) => {
+}: DiceIconsProps) {
     // eslint-disable-next-line security/detect-object-injection -- 'd1' is a number validated by typescript and gracefully falls back to default icon
     const Die1Icon = DICE_ICONS[d1] || Dices;
     // eslint-disable-next-line security/detect-object-injection -- 'd2' is a number validated by typescript and gracefully falls back to default icon

--- a/src/features/shared/components/ResourceIconRow.tsx
+++ b/src/features/shared/components/ResourceIconRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Resources } from '../../../game/core/types';
 import { RESOURCE_META } from '../config/uiConfig';
 
@@ -8,7 +7,7 @@ interface ResourceIconRowProps {
   className?: string;
 }
 
-export const ResourceIconRow: React.FC<ResourceIconRowProps> = ({ resources, size = 'sm', className = '' }) => {
+export function ResourceIconRow({ resources, size = 'sm', className = '' }: ResourceIconRowProps) {
   const iconSize = size === 'sm' ? 12 : 16;
   const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
 


### PR DESCRIPTION
**🐛 Problem:**
Legacy `React.FC` pattern and unnecessary default `React` imports are being used in multiple components across the `features/game/` and `features/board/` directories, which conflicts with modern React 19 standards and the modern JSX transform.

**🛠 Fix:**
- Converted `React.FC` definitions to standard function declarations with explicit prop types in components such as `GameLayout`, `GameScreen`, `GameHex`, `HexEdges`, `HexVertices`, `BuildingIcon`, `BoardLayer`, `DiceIcons`, and `ResourceIconRow`.
- Removed unused `import React from 'react';` imports.
- Updated namespace references (e.g., `React.useMemo`, `React.ReactNode`, `React.Fragment`) to use named imports (`useMemo`, `ReactNode`, `Fragment`).

**📉 Risk:**
Low. The changes are purely structural and syntactic; there are no logic or behavior modifications.

**🧪 Verification:**
- `npx tsc --noEmit` runs successfully with no type regressions.
- `npm run test` passes without breaking existing functionality.
- Code review was fully approved and tests were validated.

---
*PR created automatically by Jules for task [6063306022919340478](https://jules.google.com/task/6063306022919340478) started by @g1ddy*