### PR TITLE
🎨 Palette: Improve screen reader accessibility for game notifications

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,6 @@
 ## 2024-11-20 - Ensure Global Focus Visibility
 **Learning:** The custom `btn-focus-ring` utility class handles focus states effectively across the app, but floating UI controls (like panel toggles or overlays) often omit it. Furthermore, raw `lucide-react` icons inside accessible buttons (those with `aria-label`) often lack `aria-hidden="true"`, causing screen readers to misinterpret them.
 **Action:** Always apply `btn-focus-ring` to interactive elements and pass `aria-hidden="true"` to SVG icons inside labeled buttons.
+## 2025-05-06 - Verbose aria-live Notifications
+**Learning:** Complex components containing icons and abbreviated text (e.g. '+1 Trees', 'P1') render as confusing, fragmented noise in `aria-live` regions. Screen reader users prefer complete sentences.
+**Action:** When building interactive notifications, construct a visually hidden `sr-only` sentence explaining the entire interaction, and add `aria-hidden="true"` to all the decorative and abbreviated visual fragments.

--- a/src/features/coach/components/AnalystPanel.tsx
+++ b/src/features/coach/components/AnalystPanel.tsx
@@ -70,6 +70,6 @@ function AnalystPanel({ stats, onRegenerate, canRegenerate = true }: AnalystPane
       </div>
     </div>
   );
-};
+}
 
 export default AnalystPanel;

--- a/src/features/coach/components/AnalystShell.tsx
+++ b/src/features/coach/components/AnalystShell.tsx
@@ -90,4 +90,4 @@ export function AnalystShell({ children, isOpen, onToggle }: AnalystShellProps) 
       </div>
     </>
   );
-};
+}

--- a/src/features/coach/components/CoachPanel.tsx
+++ b/src/features/coach/components/CoachPanel.tsx
@@ -85,4 +85,4 @@ export function CoachPanel({
             </div>
         </div>
     );
-};
+}

--- a/src/features/coach/components/PlayerProduction.tsx
+++ b/src/features/coach/components/PlayerProduction.tsx
@@ -76,4 +76,4 @@ export function PlayerProduction({ playerPotentials, players }: PlayerProduction
             </div>
         </div>
     );
-};
+}

--- a/src/features/coach/components/PlayerProductionPotential.tsx
+++ b/src/features/coach/components/PlayerProductionPotential.tsx
@@ -39,4 +39,4 @@ export function PlayerProductionPotential({ G }: PlayerProductionPotentialProps)
             <ResourceDistribution playerPotentials={playerPotentials} players={G.players} />
         </div>
     );
-};
+}

--- a/src/features/hud/components/GameControls.tsx
+++ b/src/features/hud/components/GameControls.tsx
@@ -118,4 +118,4 @@ export function GameControls({
     }
 
     return null;
-};
+}

--- a/src/features/hud/components/GameNotification.tsx
+++ b/src/features/hud/components/GameNotification.tsx
@@ -47,7 +47,7 @@ export function GameNotification({ G }: GameNotificationProps) {
         >
             <div className="flex items-center gap-4 text-slate-100">
                 {/* Icon Section */}
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2" aria-hidden="true">
                     {/* If Rolling, show spinner. Else if Production, show Dice. Else show Ghost. */}
                     {isRolling ? (
                          <>
@@ -62,11 +62,11 @@ export function GameNotification({ G }: GameNotificationProps) {
                 </div>
 
                 {/* Vertical Separator - Only if there is content to separate */}
-                {(!isRolling && displayNotification) && <div className="h-6 w-px bg-slate-600/50" />}
+                {(!isRolling && displayNotification) && <div className="h-6 w-px bg-slate-600/50" aria-hidden="true" />}
 
                 {/* Content Section */}
                 {renderNotificationContent()}
             </div>
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/BuildBar.tsx
+++ b/src/features/hud/components/controls/BuildBar.tsx
@@ -123,4 +123,4 @@ export function BuildBar({
             })}
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/RobberControls.tsx
+++ b/src/features/hud/components/controls/RobberControls.tsx
@@ -27,4 +27,4 @@ export function RobberControls({
             />
         </div>
     );
-};
+}

--- a/src/features/hud/components/controls/SetupControls.tsx
+++ b/src/features/hud/components/controls/SetupControls.tsx
@@ -50,4 +50,4 @@ export function SetupControls({
              />
          </div>
     );
-};
+}

--- a/src/features/hud/components/controls/TurnControls.tsx
+++ b/src/features/hud/components/controls/TurnControls.tsx
@@ -75,4 +75,4 @@ export function TurnControls({
             )}
         </>
     );
-};
+}

--- a/src/features/hud/components/notifications/ProductionNotification.tsx
+++ b/src/features/hud/components/notifications/ProductionNotification.tsx
@@ -46,15 +46,24 @@ export function ProductionNotification({ evt, players, isRolling }: ProductionNo
 
                     return (
                         <div key={pid} className="flex items-center gap-2 bg-slate-700/50 rounded-full px-2 py-0.5">
+                            {/* Accessible sentence for screen readers */}
+                            <span className="sr-only">
+                                {player.name} received {Object.entries(res)
+                                    .filter(([_, amount]) => (amount || 0) > 0)
+                                    .map(([type, amount]) => `${amount} ${type}`)
+                                    .join(', ')}.
+                            </span>
+
                             {/* Player Dot */}
                             <div
                                 className="w-2.5 h-2.5 rounded-full ring-1 ring-white/20"
                                 style={{ backgroundColor: player.color }}
+                                aria-hidden="true"
                             />
-                            <span className="text-xs font-bold text-slate-300">P{Number(pid) + 1}</span>
+                            <span className="text-xs font-bold text-slate-300" aria-hidden="true">P{Number(pid) + 1}</span>
 
                             {/* Resources */}
-                            <div className="flex items-center gap-1.5 ml-1">
+                            <div className="flex items-center gap-1.5 ml-1" aria-hidden="true">
                                 {Object.entries(res).map(([type, amount]) => {
                                     if (!amount) return null;
                                     return (

--- a/src/features/hud/components/notifications/RobberNotification.tsx
+++ b/src/features/hud/components/notifications/RobberNotification.tsx
@@ -21,8 +21,12 @@ export function RobberNotification({ evt, players }: RobberNotificationProps) {
 
     return (
         <div className="flex items-center gap-3">
+            <span className="sr-only">
+                {thief.name} stole {resourceMeta ? resourceMeta.name : 'a resource'} from {victim.name}.
+            </span>
+
             {/* Thief */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2" aria-hidden="true">
                 <div
                     className="w-2.5 h-2.5 rounded-full ring-1 ring-white/20"
                     style={{ backgroundColor: thief.color }}
@@ -32,10 +36,10 @@ export function RobberNotification({ evt, players }: RobberNotificationProps) {
                 </span>
             </div>
 
-            <ArrowRight size={14} className="text-slate-500" />
+            <ArrowRight size={14} className="text-slate-500" aria-hidden="true" />
 
             {/* Victim */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2" aria-hidden="true">
                 <div
                     className="w-2.5 h-2.5 rounded-full ring-1 ring-white/20"
                     style={{ backgroundColor: victim.color }}
@@ -47,7 +51,7 @@ export function RobberNotification({ evt, players }: RobberNotificationProps) {
 
             {/* Resource (if visible/known) */}
             {resourceMeta && (
-                <div className="flex items-center gap-1.5 ml-1 bg-slate-700/50 pl-2 pr-3 py-0.5 rounded-full">
+                <div className="flex items-center gap-1.5 ml-1 bg-slate-700/50 pl-2 pr-3 py-0.5 rounded-full" aria-hidden="true">
                     <resourceMeta.Icon size={14} className={resourceMeta.color} />
                     <span className="text-xs font-bold text-slate-300 capitalize">
                         {resourceMeta.name}
@@ -56,4 +60,4 @@ export function RobberNotification({ evt, players }: RobberNotificationProps) {
             )}
         </div>
     );
-};
+}


### PR DESCRIPTION
💡 **What:** Added comprehensive `sr-only` sentences to in-game notifications (Robber and Production events) and applied `aria-hidden="true"` to visual fragments.
🎯 **Why:** Complex visual shorthands like `P1`, colored dots, and `+1 [Icon]` create fragmented and confusing noise in `aria-live` regions for screen reader users. Natural language sentences provide much clearer context.
♿ **Accessibility:** Screen readers will now announce full sentences like "Player 1 received 2 wood" or "Player 2 stole a resource from Player 1" instead of a chaotic list of abbreviations and icon roles.

---
*PR created automatically by Jules for task [5876743879901230585](https://jules.google.com/task/5876743879901230585) started by @g1ddy*