### PR TITLE
⚡ Bolt: Refactor port owner lookup to zero-allocation loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2026-03-31 - Memoizing Deterministic State Lookups in Render Loops
 **Learning:** Iterating through string arrays and performing object property lookups (`safeCheck` on `G.board.hexes`) to determine UI ownership for hundreds of vertices/edges per frame causes a measurable performance drop. Because the board topology is effectively static during gameplay, these checks constantly yield the same result.
 **Action:** Use a simple JavaScript `Map` to cache the result of deterministic state lookups based on their input parameters (e.g., `parts.join('|')`). Invalidate the cache only when the underlying state reference (`G.board.hexes`) actually changes, rather than recalculating on every React render.
+## 2026-05-12 - Zero-Allocation Iteration in React Render Loops
+**Learning:** Chained array methods like `.map().find()` create unnecessary intermediate array allocations, adding Garbage Collection (GC) pressure inside high-frequency render loops.
+**Action:** Use zero-allocation `for...of` loops with early `break` statements when checking conditions or searching for items within frequently rendered lists (e.g. HexEdges or tooltips).

--- a/src/features/board/components/HexEdges.tsx
+++ b/src/features/board/components/HexEdges.tsx
@@ -110,7 +110,15 @@ export const HexEdges: React.FC<HexEdgesProps> = ({
 
                 let portElement = null;
                 if (port) {
-                    const portOwner = port.vertices.map(vId => safeGet(G.board.vertices, vId)?.owner).find(Boolean);
+                    let portOwner = undefined;
+                    for (const vId of port.vertices) {
+                        const owner = safeGet(G.board.vertices, vId)?.owner;
+                        if (owner) {
+                            portOwner = owner;
+                            break;
+                        }
+                    }
+
                     portElement = (
                         <Port key={`port-${eId}`} cx={midX} cy={midY} angle={angle} type={port.type}
                               ownerColor={portOwner ? G.players[portOwner]?.color : null}


### PR DESCRIPTION
### 💡 What
Refactored the port owner logic inside `HexEdges.tsx` to use a zero-allocation `for...of` loop instead of chained `port.vertices.map(...).find(Boolean)`. 

### 🎯 Why
Inside React render loops, particularly lists that process dozens of elements per frame (like the board edges), creating intermediary arrays via `.map` operations builds up Garbage Collection (GC) pressure unnecessarily.

### 📊 Impact
Micro-optimization. Prevents $O(N)$ intermediary array allocations where N is the number of vertices attached to a port, reducing GC spikes during rapid board renders or hover states.

### 🔬 Measurement
Run `npm run build` and `npm run test:e2e` to verify no visual regressions exist, confirming the board and its port tooltips load correctly with stable FPS.

---
*PR created automatically by Jules for task [13770055672053850830](https://jules.google.com/task/13770055672053850830) started by @g1ddy*