### PR TITLE
🎨 Palette: Accessible Tooltips for Disabled ActionButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,7 @@
 ## 2024-11-20 - Ensure Global Focus Visibility
 **Learning:** The custom `btn-focus-ring` utility class handles focus states effectively across the app, but floating UI controls (like panel toggles or overlays) often omit it. Furthermore, raw `lucide-react` icons inside accessible buttons (those with `aria-label`) often lack `aria-hidden="true"`, causing screen readers to misinterpret them.
 **Action:** Always apply `btn-focus-ring` to interactive elements and pass `aria-hidden="true"` to SVG icons inside labeled buttons.
+
+## 2024-05-27 - Disabled Button Tooltips and Interaction Prevention
+**Learning:** When using `aria-disabled="true"` instead of the native `disabled` attribute to allow tooltips to appear on hover and focus, the element remains fully interactive to the browser (e.g., Space/Enter keys trigger clicks).
+**Action:** Always intercept the `onClick` event in the underlying component (like `ActionButton`) and conditionally call `e.preventDefault()` and exit early if the `disabled` prop is true, effectively mimicking native disabled behavior safely.

--- a/src/features/hud/components/controls/ActionButton.tsx
+++ b/src/features/hud/components/controls/ActionButton.tsx
@@ -11,11 +11,21 @@ export function ActionButton({
     disabled,
     ...props
 }: ActionButtonProps) {
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+        if (disabled) {
+            e.preventDefault();
+            return;
+        }
+        if (onClick) {
+            onClick(e);
+        }
+    };
+
     return (
         <button
-            onClick={onClick}
+            onClick={handleClick}
             className={className}
-            disabled={disabled}
+            aria-disabled={disabled ? "true" : undefined}
             {...props}
         >
             <span className="text-base font-bold">{label}</span>

--- a/src/features/hud/components/controls/RobberControls.tsx
+++ b/src/features/hud/components/controls/RobberControls.tsx
@@ -24,6 +24,8 @@ export function RobberControls({
                         : "bg-slate-700 cursor-not-allowed text-slate-400 border border-slate-600"
                 }`}
                 label={hasSelection ? "Confirm Robber Placement" : "Select New Location"}
+                data-tooltip-id={!hasSelection ? "ui-tooltip" : undefined}
+                data-tooltip-content={!hasSelection ? "Select a hex to place the robber" : undefined}
             />
         </div>
     );

--- a/src/features/hud/components/controls/SetupControls.tsx
+++ b/src/features/hud/components/controls/SetupControls.tsx
@@ -36,6 +36,8 @@ export function SetupControls({
                     disabled={!canInteract}
                     className={`${baseClasses} ${canInteract ? interactiveClasses : disabledClasses}`}
                     label={canInteract ? "Begin Placement" : "Waiting for Opponent..."}
+                    data-tooltip-id={!canInteract ? "ui-tooltip" : undefined}
+                    data-tooltip-content={!canInteract ? "Waiting for opponent to finish their turn" : undefined}
                 />
             </div>
          );


### PR DESCRIPTION
💡 **What:** Replaced the native HTML `disabled` attribute with `aria-disabled` on HUD `ActionButton` components and added contextual tooltips.
🎯 **Why:** Native disabled elements drop out of the tab order and cannot trigger tooltips. Using `aria-disabled` allows keyboard users to focus the element, hear its disabled state via screen readers, and see *why* it is disabled via a tooltip.
📸 **Before/After:** Disabled ActionButtons (like "Waiting for Opponent..." or "Select New Location") now show a helpful tooltip on hover/focus.
♿ **Accessibility:**
- Ensures disabled state remains discoverable via keyboard (`Tab`).
- Screen readers announce the button as "disabled".
- Tooltip attributes (`data-tooltip-id` and `data-tooltip-content`) provide explicit instructions attached directly to the focusable element.
- Added `e.preventDefault()` inside `ActionButton` to safely mimic native disabled click prevention since `aria-disabled` does not block events.

---
*PR created automatically by Jules for task [1940234602441061013](https://jules.google.com/task/1940234602441061013) started by @g1ddy*