### PR TITLE
🏛️ Archon: Reduce complexity in OverlayEdge and OverlayVertex (Health: 93.0)

### DIFF
--- a/.jules/archon.md
+++ b/.jules/archon.md
@@ -30,3 +30,6 @@ This journal records critical architectural blockers and recurring anti-patterns
 ## 2026-04-12 - [High Complexity Logic]
 **Observation:** `HexVertices.tsx` had high cyclomatic complexity (13) due to nested conditional logic inside its `.map` rendering loop for determining interactive and ghost states.
 **Strategy:** Extracted the state determination logic into a pure helper function `getVertexInteractiveState`. This decoupled state derivation from React rendering, reducing cyclomatic complexity below 10 and removing the file from the top 10 most complex list.
+## 2026-05-17 - [High Complexity Logic]
+**Observation:** `OverlayEdge.tsx` and `OverlayVertex.tsx` had high cyclomatic complexity (12) due to inline derivation of display states combined with inline arrow functions.
+**Strategy:** Extracted the component body into named functions before `React.memo` to properly attribute complexity, and extracted complex logic into helper functions. Reduced cyclomatic complexity to below 10 and removed them from the top 10 most complex list.

--- a/docs/COMPLEXITY.md
+++ b/docs/COMPLEXITY.md
@@ -92,9 +92,9 @@ Following the "Namespace Restructure" refactor to align with directional layers 
 
 ## 🚨 Automated Complexity Report
 
-**Last Updated:** 2026-04-12
+**Last Updated:** 2026-05-17
 
-### 🏥 Repository Health Score: **91.0 / 100**
+### 🏥 Repository Health Score: **93.0 / 100**
 
 *   **Formula**: 100 - Penalties for Files exceeding thresholds (LOC > 300, Complexity > 10, Fan-Out > 15).
 *   **Total Files Scanned**: 112
@@ -107,24 +107,24 @@ _Score = (LOC/10) + (Complexity*2) + (FanOut*2) + (Instability*20)_
 | `src/bots/logic/OptimalMoveFilter.ts` | **76.6** | 228 | 10 | 8 | 0.89 |
 | `src/features/board/components/HexEdges.tsx` | **74.3** | 140 | 10 | 11 | 0.92 |
 | `src/game/Game.ts` | **72.8** | 121 | 7 | 14 | 0.93 |
-| `src/game/analysis/coach.ts` | **70.1** | 200 | 10 | 11 | 0.41 |
+| `src/game/analysis/coach.ts` | **71** | 209 | 10 | 11 | 0.41 |
 | `src/game/analysis/advisors/SpatialAdvisor.ts` | **69.5** | 211 | 7 | 9 | 0.82 |
 | `src/game/analysis/advisors/RoadAdvisor.ts` | **68.9** | 238 | 8 | 6 | 0.86 |
-| `src/features/board/components/HexVertices.tsx` | **67.2** | 134 | 10 | 8 | 0.89 |
 | `src/features/game/GameLayout.tsx` | **66.5** | 210 | 7 | 7 | 0.88 |
 | `src/features/board/components/HexOverlays.tsx` | **65.6** | 140 | 11 | 7 | 0.78 |
 | `src/game/rules/moveValidation.ts` | **64.1** | 139 | 6 | 10 | 0.91 |
+| `src/game/rules/queries.ts` | **62.2** | 234 | 7 | 7 | 0.54 |
 
 ### 🧠 Top 10 Logic-Heavy Files (Cyclomatic Complexity)
 | File | Max Complexity | LOC |
 | :--- | :--- | :--- |
-| `src/features/board/components/OverlayEdge.tsx` | **12** | 66 |
-| `src/features/board/components/OverlayVertex.tsx` | **12** | 100 |
 | `src/features/coach/logic/coachUtils.ts` | **11** | 120 |
 | `src/features/board/components/HexOverlays.tsx` | **11** | 140 |
-| `src/features/hud/components/controls/TurnControls.tsx` | **11** | 80 |
+| `src/features/hud/components/controls/TurnControls.tsx` | **11** | 79 |
 | `src/features/hud/components/PlayerPanel.tsx` | **11** | 127 |
 | `src/features/game/components/TooltipRenderers.tsx` | **11** | 99 |
 | `src/game/rules/validator.ts` | **11** | 75 |
 | `src/game/rules/enumerator.ts` | **11** | 109 |
-| `src/game/analysis/coach.ts` | **10** | 200 |
+| `src/game/analysis/coach.ts` | **10** | 209 |
+| `src/bots/logic/MoveScorer.ts` | **10** | 80 |
+| `src/bots/logic/OptimalMoveFilter.ts` | **10** | 228 |

--- a/src/features/board/components/OverlayEdge.tsx
+++ b/src/features/board/components/OverlayEdge.tsx
@@ -18,18 +18,30 @@ export interface OverlayEdgeProps {
     tooltip?: string;
 }
 
-export const OverlayEdge = React.memo(({
+interface EdgeDisplayState {
+    ghostFill: string;
+    ghostOpacity: number;
+    tooltipId?: string;
+}
+
+function getEdgeDisplayState(
+    isRecommended?: boolean,
+    heatmapColor?: string,
+    tooltip?: string
+): EdgeDisplayState {
+    const ghostFill = isRecommended ? '#FFD700' : (heatmapColor || 'white');
+    const ghostOpacity = isRecommended ? 0.8 : (heatmapColor ? 0.6 : 0.5);
+    const hasRecommendation = isRecommended || !!heatmapColor;
+    const tooltipId = hasRecommendation ? "coach-tooltip" : (tooltip ? "ui-tooltip" : undefined);
+    return { ghostFill, ghostOpacity, tooltipId };
+}
+
+function OverlayEdgeComponent({
     eId, cx, cy, angle, isOccupied, ownerColor,
     isClickable, isGhost, onClick,
     isRecommended, heatmapColor, tooltip
-}: OverlayEdgeProps) => {
-
-    const ghostFill = isRecommended ? '#FFD700' : (heatmapColor || 'white');
-    const ghostOpacity = isRecommended ? 0.8 : (heatmapColor ? 0.6 : 0.5);
-
-    // Use heatmapColor as the indicator for any recommendation, not just top 3 (isRecommended)
-    const hasRecommendation = isRecommended || !!heatmapColor;
-    const tooltipId = hasRecommendation ? "coach-tooltip" : (tooltip ? "ui-tooltip" : undefined);
+}: OverlayEdgeProps) {
+    const { ghostFill, ghostOpacity, tooltipId } = getEdgeDisplayState(isRecommended, heatmapColor, tooltip);
 
     return (
          <g onClick={(e) => {
@@ -60,6 +72,7 @@ export const OverlayEdge = React.memo(({
             )}
         </g>
     );
-});
+}
 
+export const OverlayEdge = React.memo(OverlayEdgeComponent);
 OverlayEdge.displayName = 'OverlayEdge';

--- a/src/features/board/components/OverlayVertex.tsx
+++ b/src/features/board/components/OverlayVertex.tsx
@@ -22,11 +22,16 @@ export interface OverlayVertexProps {
     showResourceHeatmap: boolean;
 }
 
-export const OverlayVertex = React.memo(({
+function getHighlightClass(isTop3?: boolean, showResourceHeatmap?: boolean) {
+    const opacityClass = isTop3 || showResourceHeatmap ? 'opacity-100' : 'opacity-0 group-hover:opacity-100';
+    return "coach-highlight transition-opacity duration-200 " + opacityClass;
+}
+
+function OverlayVertexComponent({
     vId, cx, cy, vertex, ownerColor,
     isClickable, isGhost, onClick, buildMode,
     hasRecommendation, heatmapColor, isTop3, showResourceHeatmap
-}: OverlayVertexProps) => {
+}: OverlayVertexProps) {
     const isOccupied = !!vertex;
 
     return (
@@ -59,9 +64,7 @@ export const OverlayVertex = React.memo(({
 
             {hasRecommendation && (
                  <g
-                    className={`coach-highlight transition-opacity duration-200 ${
-                        isTop3 || showResourceHeatmap ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-                    }`}
+                    className={getHighlightClass(isTop3, showResourceHeatmap)}
                     data-tooltip-id="coach-tooltip"
                     data-tooltip-content={vId}
                  >
@@ -94,6 +97,7 @@ export const OverlayVertex = React.memo(({
             )}
         </g>
     );
-});
+}
 
+export const OverlayVertex = React.memo(OverlayVertexComponent);
 OverlayVertex.displayName = 'OverlayVertex';


### PR DESCRIPTION
Problem:
`OverlayEdge.tsx` and `OverlayVertex.tsx` were flagged in `docs/COMPLEXITY.md` as logic-heavy components with a cyclomatic complexity of 12 due to inline derivation of display states and anonymous arrow functions used within `React.memo`.

Fix:
- Extracted display state logic (`ghostFill`, `ghostOpacity`, `tooltipId`) in `OverlayEdge.tsx` into a `getEdgeDisplayState` helper function.
- Extracted highlight class logic in `OverlayVertex.tsx` into a `getHighlightClass` helper function.
- Converted anonymous component declarations to named functions (`OverlayEdgeComponent`, `OverlayVertexComponent`) prior to `React.memo` wrapping.

Metrics:
Repo Health Score changed from 91.0 to 93.0. Cyclomatic complexity for both files is now under 10.

---
*PR created automatically by Jules for task [8728457336708235118](https://jules.google.com/task/8728457336708235118) started by @g1ddy*