### PR TITLE
💎 Refract: Refactor Any Types in Move Enumerator

### DIFF
--- a/.jules/refract.md
+++ b/.jules/refract.md
@@ -1,1 +1,2 @@
 ## 2026-03-11 - [Legacy React.FC Usage] **Observation:** Usage of React.FC instead of semantic function declarations. **Strategy:** Prefer semantic function declarations (e.g., export function Component(props: Props)) over React.FC as per React 19 standards.
+## 2026-07-13 - [Unexpected any Usage] **Observation:** Usage of `any` to cast empty argument lists for dynamically determined moves. **Strategy:** Replaced `as any` with `as unknown as MoveArguments[typeof moveKey]` to enforce strict type checking and avoid type unsafety warnings without modifying actual runtime logic.

--- a/src/game/rules/enumerator.ts
+++ b/src/game/rules/enumerator.ts
@@ -98,8 +98,8 @@ export const enumerate = (G: GameState, ctx: Ctx, playerID: string): GameAction[
             // Handle Non-Parameterized Moves (Everything else)
             // Use RuleEngine for ALL non-parameterized moves to ensure correctness
             const moveKey = moveName as keyof MoveArguments;
-            if (RuleEngine.validateMove(G, ctx, moveKey, [] as any).isValid) {
-                 moves.push(makeMove(moveKey, [] as any));
+            if (RuleEngine.validateMove(G, ctx, moveKey, [] as unknown as MoveArguments[typeof moveKey]).isValid) {
+                 moves.push(makeMove(moveKey, [] as unknown as MoveArguments[typeof moveKey]));
             }
         }
     });

--- a/src/game/rules/enumerator.ts
+++ b/src/game/rules/enumerator.ts
@@ -97,9 +97,14 @@ export const enumerate = (G: GameState, ctx: Ctx, playerID: string): GameAction[
         } else {
             // Handle Non-Parameterized Moves (Everything else)
             // Use RuleEngine for ALL non-parameterized moves to ensure correctness
-            const moveKey = moveName as keyof MoveArguments;
-            if (RuleEngine.validateMove(G, ctx, moveKey, [] as unknown as MoveArguments[typeof moveKey]).isValid) {
-                 moves.push(makeMove(moveKey, [] as unknown as MoveArguments[typeof moveKey]));
+            // Create a union of all MoveArguments keys where the argument tuple is empty
+            type EmptyArgMoveKeys = {
+                [K in keyof MoveArguments]: MoveArguments[K] extends [] ? K : never
+            }[keyof MoveArguments];
+
+            const moveKey = moveName as EmptyArgMoveKeys;
+            if (RuleEngine.validateMove(G, ctx, moveKey, []).isValid) {
+                 moves.push(makeMove(moveKey, []));
             }
         }
     });


### PR DESCRIPTION
🐛 Problem: `src/game/rules/enumerator.ts` used `[] as any` to bypass TypeScript checks for empty argument lists of dynamic moves.
🛠 Fix: Replaced `[] as any` with `[] as unknown as MoveArguments[typeof moveKey]` to eliminate the `any` usage while still correctly satisfying the type requirements.
📉 Risk: Low
🧪 Verification: Ran `npm run lint` and `npm run test` successfully. Code review confirmed correctness.

---
*PR created automatically by Jules for task [4151416716782139912](https://jules.google.com/task/4151416716782139912) started by @g1ddy*